### PR TITLE
Give dev/pn544 the right owner and permissions

### DIFF
--- a/rootdir/etc/ueventd.qcom.rc
+++ b/rootdir/etc/ueventd.qcom.rc
@@ -187,7 +187,7 @@
 #nfc permissions
 /dev/nfc-nci              0660    nfc         nfc
 /dev/assd                 0660    nfc         nfc
-
+dev/pn544                 0660    nfc         nfc
 # UIO devices
 /dev/uio0                 0660   system     system
 /dev/uio1                 0660   system     system


### PR DESCRIPTION
On first boot nfc is powered on, booting after that it is in the last state.
I think thats normal.